### PR TITLE
Updated to use the latest Tuya-Convert release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,8 @@ END
 sync
 
 echo " * mounting raspbian root image"
+trap "losetup --detach-all" EXIT
+losetup --detach-all
 loop_dev=$(losetup -P -f --show raspbian-lite.img)
 
 echo " * resizing root partition"

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,8 @@ rngd -r /dev/urandom
 echo 1 > /proc/sys/kernel/panic
 
 echo " * downloading tuya-convert"
-curl -L https://github.com/ct-Open-Source/tuya-convert/archive/94acc3bb020361266ceb74f082e1d25c92a60345.tar.gz -o tuya-convert.tar.gz
+latest_tuya-convert="$(curl --silent --head https://github.com/ct-Open-Source/tuya-convert/releases/latest | grep "^location:" | awk -F '/tag/' '{print $2}')"
+curl -L https://github.com/ct-Open-Source/tuya-convert/archive/${latest_tuya-convert}.tar.gz -o tuya-convert.tar.gz
 tar xvf tuya-convert.tar.gz
 rm tuya-convert.tar.gz
 mv tuya-convert-* tuya-convert


### PR DESCRIPTION
Thanks for an awesome project. I attempted to use it but got a 'vtrust-recovry' SSID instead of a working unit. Google told me to update the Tuya-Convert codebase, so this is what that PR does... on every build :-)

Every time you do a build, it will get the latest release from Github.
Oh, and I had issues with loopback devices being left around, so I've put in a fix for that too.